### PR TITLE
FIX: add 'function' to top-level dbdtree node list

### DIFF
--- a/pyPDB/dbdlint.py
+++ b/pyPDB/dbdlint.py
@@ -366,6 +366,11 @@ dbdtree = {
             'body':False,
             'wholefn':wholeDevice,
         },
+        'function':{
+            'nargs':1,
+            'quote':[False],
+            'body':False,
+        },
         'registrar':{
             'nargs':1,
             'quote':[False],


### PR DESCRIPTION
Unless our generated database definition is malformed, the pypdb top-level entries in pyPDB.dbdlint.dbdtree appear to be missing `'function'`:

For example, from our IOC's built `.dbd` file:
```
registrar(asynInterposeEosRegister)
...
function(scanMon)
function(rebootProc)
function(scanMonInit)
```

This leads to linter errors:
```
Unknown node or out of context: Block(function, ['scanMonInit'], None)
```